### PR TITLE
the date filter test

### DIFF
--- a/test/fixtures/swig/datefilter.swig
+++ b/test/fixtures/swig/datefilter.swig
@@ -1,1 +1,1 @@
-<span>Date: {{ date | date('m-d-Y') }}</span>
+<span>Date: {{ date | date('n-j-Y') }}</span>

--- a/test/fixtures/swig/ifelse.swig
+++ b/test/fixtures/swig/ifelse.swig
@@ -7,3 +7,4 @@
 <p>not for a while</p>
 {% elif drinksConsumed > 4 %}
 <p>do not puke on me</p>
+{% endif %}

--- a/test/swig.js
+++ b/test/swig.js
@@ -115,8 +115,9 @@ describe('Swig', function(){
   it('should format a date', function *(){
 
     let date = new Date(2015, 0 , 9);
-
-    yield testHelper('datefilter', /Date: 01-09-2015/, false, {date: date});
+    
+    let date_string = date.getUTCMonth() + 1 + '-' + date.getUTCDate() + '-' + date.getUTCFullYear();
+    yield testHelper('datefilter', new RegExp('Date: ' + date_string), true, {date: date});
 
   }); 
 


### PR DESCRIPTION
My timezone setting is GMT+0800, so the swig output is always '2015-01-08' for the Date(2015, 0, 9) in origin files and the test always failed. And I believe if you add more sections like hour, minute, second, especially hour, your test would fail too as you may not expect. 

Well, if you always live in GMT+0000, what above would never make sense to you. lol

[swig date filter](https://paularmstrong.github.io/swig/docs/filters/#date) works like the UTC formatting, if the offset is ignored. In real app, I may just introduce lib like moment.js to take care of this annoying issue.

Wish you would extend this test further and help me and more people to get a better understand of it. 

```
> d = new Date(2015, 0, 9);
Fri Jan 09 2015 00:00:00 GMT+0800 (CST)
> d.toString()
'Fri Jan 09 2015 00:00:00 GMT+0800 (CST)'
> d.toUTCString()
'Thu, 08 Jan 2015 16:00:00 GMT'
> d.toLocaleString()
'Fri Jan 09 2015 00:00:00 GMT+0800 (CST)'
```

regarding the `endif`, just watch you missed it in the video.

Your podcasting is awesome. There got to be lots of efforts. Great Job. I really appreciate it.
